### PR TITLE
R Fjern adressefelter i innvilgelsesbrevet og fiks navngivning på datofelt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # tiltakspenger-pdfgen
 PDF generator for tiltakspenger. Kjør lokalt docker image med  `./run_development.sh`
 
-PDFene kan testes lokalt på `http://localhost:8081/api/v1/genpdf/<application>/<template>`, f.eks.
-http://localhost:8081/api/v1/genpdf/tpts/vedtakInnvilgelse
+PDFene kan testes lokalt på `http://localhost:8085/api/v1/genpdf/<application>/<template>`, f.eks.
+http://localhost:8085/api/v1/genpdf/tpts/vedtakInnvilgelse
 
 Templatene vil bruke flettedata fra json-fil med samme navn som template i `data/tpts`
 

--- a/data/tpts/vedtakInnvilgelse.json
+++ b/data/tpts/vedtakInnvilgelse.json
@@ -1,14 +1,8 @@
 {
   "personalia": {
-    "dato": "01.01.2021",
     "ident": "12345678901",
     "fornavn": "Planet",
     "etternavn": "Planetus",
-    "adresse": "Melkeveien",
-    "husnummer": "20",
-    "bruksenhet": "H103",
-    "postnummer": "9807",
-    "poststed": "Uranus",
     "antallBarn": 0
   },
   "tiltaksinfo": {
@@ -17,10 +11,10 @@
     "tiltaksnummer": "2023/0263674",
     "arrangør": "DAHLS GRILL ÅRNES"
   },
+  "datoForUtsendelse": "01.01.2023",
   "fraDato": "2025-01-01",
   "tilDato": "2025-01-01",
   "saksnummer": "123456789",
-  "innsendingTidspunkt": "2023-09-07T12:18:38.487383",
   "barnetillegg": false,
   "saksbehandler": "MOT BAKKE",
   "kontor": "NAV Hvaler"

--- a/templates/tpts/partials/base.hbs
+++ b/templates/tpts/partials/base.hbs
@@ -115,7 +115,7 @@
             padding-right: 0.2em;
         }
     </style>
-    <title>Supplerende stønad</title>
+    <title>Tiltakspenger</title>
 </head>
 
 <body>
@@ -126,11 +126,9 @@
 
             <div class="personalia">
                 <p>{{fornavn}} {{etternavn}}</p>
-                <p>{{adresse}} {{husnummer}}, {{bruksenhet}}</p>
-                <p>{{postnummer}} {{poststed}}</p>
             </div>
             <div class="dato">
-                <p>Dato: {{dato}}</p>
+                <p>Dato: {{datoForUtsendelse}}</p>
             </div>
         </div>
         {{/with}}


### PR DESCRIPTION
## Beskrivelse
<!--- Beskriv endringene som gjøres i denne PR-en -->
Vi fjerner feltene for adresse i brevet da dette ikke er noe vi tror vi trenger å fylle inn i dokumentet. Dokdist håndterer adressering utenom innholdet i brevet. Vi endrer også navn på datofelt slik at det er tydeligere hva den representerer og flytter den ut av personaliaobjektet da den nok ikke hører hjemme der.

## Kommentarer
<!--- Er det noe mer som bør opplyses om til den som ser over? -->
Vi endrer også på portnummer i readme slik at det reflekterer endringen i run_development som er gjort tidligere.

## Visuelle endringer:
<!--- Legg ved skjermbilder av de visuelle endringene dersom det er relevant -->
![Screenshot 2024-02-28 at 15 03 25](https://github.com/navikt/tiltakspenger-pdfgen/assets/44436236/16f398dd-f782-4d15-8759-7f374543c2ad)
