### PR TITLE
1315 fjerner tiltaksinformasjon for innvilgelse og revurdering, støtt…

### DIFF
--- a/data/tpts/revurderingsvedtak.json
+++ b/data/tpts/revurderingsvedtak.json
@@ -11,6 +11,5 @@
   "beslutterNavn": "Pelle Parafin",
   "kontor": "Nav Hvaler",
   "rammevedtakFraDato": "1. januar 2025",
-  "rammevedtakTilDato": "31. desember 2025",
-  "tiltaksnavn": "Jobbklubb"
+  "rammevedtakTilDato": "31. desember 2025"
 }

--- a/data/tpts/utbetalingsvedtak.json
+++ b/data/tpts/utbetalingsvedtak.json
@@ -1,7 +1,5 @@
 {
   "meldekortId": "meldekort_01JCQV1M22WR1D9VGC43MSRP0P",
-  "eksternDeltagelseId": "1231-234-3242-23432",
-  "eksternGjennomføringId": "1231-234-3242-23432",
   "saksnummer": "3424234132",
   "meldekortPeriode": {
     "fom": "1. januar 2024",
@@ -129,7 +127,19 @@
       "reduksjon": "Ytelsen faller bort"
     }
   ],
-  "tiltakstype": "GRUPPE_AMO",
-  "tiltaksnavn": "Gruppe AMO",
+  "tiltak": [
+    {
+      "tiltakstypenavn": "Arbeidsmarkedsopplæring (gruppe)",
+      "tiltakstype": "GRUPPE_AMO",
+      "eksternDeltagelseId": "1231-234-3242-23432",
+      "eksternGjennomføringId": "1231-234-3242-23432"
+    },
+    {
+      "tiltakstypenavn": "Jobbklubb",
+      "tiltakstype": "JOBBK",
+      "eksternDeltagelseId": "1111-234-3242-23432",
+      "eksternGjennomføringId": "2222-234-3242-23432"
+    }
+  ],
   "iverksattTidspunkt": "2024-11-15 13:05:15"
 }

--- a/data/tpts/vedtakInnvilgelse.json
+++ b/data/tpts/vedtakInnvilgelse.json
@@ -14,7 +14,6 @@
   "satsBarn": 55,
   "rammevedtakFraDato": "1. januar 2024",
   "rammevedtakTilDato": "31. desember 2024",
-  "tiltaksnavn": "Arbeidstrening",
   "tilleggstekst": "",
   "forhandsvisning": true
 }

--- a/templates/tpts/revurderingsvedtak.hbs
+++ b/templates/tpts/revurderingsvedtak.hbs
@@ -1,11 +1,11 @@
 {{#> tpts/partials/base}}
 <section>
-        <h1>Nav har stanset dine tiltakspenger under {{tiltaksnavn}}</h1>
+        <h1>Nav har stanset tiltakspengene dine</h1>
 
         <h2>Vedtak</h2>
 
         <p>
-        Tiltakspengene {{#if barnetillegg}}og barnetillegg{{/if}} stanses fra og med {{rammevedtakFraDato}} til og med {{rammevedtakTilDato}} fordi du ikke lenger deltar i {{tiltaksnavn}}.
+        Tiltakspengene {{#if barnetillegg}}og barnetillegg{{/if}} stanses fra og med {{rammevedtakFraDato}} til og med {{rammevedtakTilDato}} fordi du ikke lenger deltar i arbeidsmarkedstiltak.
         </p>
         <p>
             For å ha rett til tiltakspenger må du delta i arbeidsmarkedstiltak som gir rett til tiltakspenger.

--- a/templates/tpts/utbetalingsvedtak.hbs
+++ b/templates/tpts/utbetalingsvedtak.hbs
@@ -26,13 +26,14 @@
     {{/with}}
 </ul>
 <h2>Tiltak</h2>
-<ul class="informasjon">
-    <li><b>Tiltaksnavn:</b> {{tiltaksnavn}}</li>
-    <li><b>Tiltakstype:</b> {{tiltakstype}}</li>
-    <li><b>DeltagelseId:</b> {{eksternDeltagelseId}}</li>
-    <li><b>GjennomføringId:</b> {{eksternGjennomføringId}}</li>
-
-</ul>
+{{#each tiltak}}
+    <ul class="informasjon">
+        <li><b>Tiltaksnavn:</b> {{tiltakstypenavn}}</li>
+        <li><b>Tiltakstype:</b> {{tiltakstype}}</li>
+        <li><b>DeltagelseId:</b> {{eksternDeltagelseId}}</li>
+        <li><b>GjennomføringId:</b> {{eksternGjennomføringId}}</li>
+    </ul>
+{{/each}}
 
 <h2>Meldekortdager</h2>
 <table>

--- a/templates/tpts/vedtakInnvilgelse.hbs
+++ b/templates/tpts/vedtakInnvilgelse.hbs
@@ -4,7 +4,7 @@
 
         <h2>Vedtak</h2>
 
-        <p>Du får tiltakspenger {{#if barnetillegg}}og barnetillegg{{/if}} fra og med {{rammevedtakFraDato}} til og med {{rammevedtakTilDato}} fordi du deltar på {{tiltaksnavn}}.</p>
+        <p>Du får tiltakspenger {{#if barnetillegg}}og barnetillegg{{/if}} fra og med {{rammevedtakFraDato}} til og med {{rammevedtakTilDato}} fordi du deltar på arbeidsmarkedstiltak.</p>
         <p>Tiltakspengene er {{currency_no sats true}} kroner per dag du deltar i arbeidsmarkedstiltaket.</p>
 
         {{#if barnetillegg}}


### PR DESCRIPTION
…er liste for utbetalingsvedtak

## Beskrivelse
Vi har blitt enige om at det ikke gir så mye verdi å ha med navn på tiltakstypen i brevene for innvilgelse og revurdering, og at informasjon om dette må dekkes av fritekst. For utbetalingsvedtaket må vi støtte en liste med tiltak som er relevante for utbetalingsperioden. 

Merk at endringen for utbetalingsvedtak er en breaking change og forutsetter at vi har kontroll på når det opprettes slike vedtak i prod (hvis ikke må vi endre slik at det blir bakoverkompatibelt). 

## Kommentarer
https://trello.com/c/W9ifbenn/1315-st%C3%B8tte-at-vi-f%C3%A5r-flere-tiltak-fra-arena-komet-n%C3%A5r-vi-s%C3%B8ker-opp-et-fnr

## Visuelle endringer:
<!--- Legg ved skjermbilder av de visuelle endringene dersom det er relevant -->
