### PR TITLE
1337 Stansbrev oppdatert med nye tekster

### DIFF
--- a/data/tpts/revurderingsvedtak.json
+++ b/data/tpts/revurderingsvedtak.json
@@ -10,6 +10,9 @@
   "saksbehandlerNavn": "Kåre Kropp",
   "beslutterNavn": "Pelle Parafin",
   "kontor": "Nav Hvaler",
-  "rammevedtakFraDato": "1. januar 2025",
-  "rammevedtakTilDato": "31. desember 2025"
+  "virkningsperiodeFraDato": "1. januar 2025",
+  "virkningsperiodeTilDato": "31. desember 2025",
+  "valgtHjemmelTekst": "du mottar en annen stønad til livsopphold. Deltakere som mottar andre stønader til livsopphold, har ikke rett til tiltakspenger og barnetillegg etter forskrift om tiltakspenger § 7",
+  "tilleggstekst": "",
+  "forhandsvisning": true
 }

--- a/data/tpts/revurderingsvedtak.json
+++ b/data/tpts/revurderingsvedtak.json
@@ -12,7 +12,7 @@
   "kontor": "Nav Hvaler",
   "virkningsperiodeFraDato": "1. januar 2025",
   "virkningsperiodeTilDato": "31. desember 2025",
-  "valgtHjemmelTekst": "du mottar en annen stønad til livsopphold. Deltakere som mottar andre stønader til livsopphold, har ikke rett til tiltakspenger og barnetillegg etter forskrift om tiltakspenger § 7.",
+  "valgtHjemmelTekst": ["du mottar en annen stønad til livsopphold. Deltakere som mottar andre stønader til livsopphold, har ikke rett til tiltakspenger og barnetillegg etter forskrift om tiltakspenger § 7."],
   "tilleggstekst": "",
   "forhandsvisning": true
 }

--- a/data/tpts/revurderingsvedtak.json
+++ b/data/tpts/revurderingsvedtak.json
@@ -12,7 +12,7 @@
   "kontor": "Nav Hvaler",
   "virkningsperiodeFraDato": "1. januar 2025",
   "virkningsperiodeTilDato": "31. desember 2025",
-  "valgtHjemmelTekst": "du mottar en annen stønad til livsopphold. Deltakere som mottar andre stønader til livsopphold, har ikke rett til tiltakspenger og barnetillegg etter forskrift om tiltakspenger § 7",
+  "valgtHjemmelTekst": "du mottar en annen stønad til livsopphold. Deltakere som mottar andre stønader til livsopphold, har ikke rett til tiltakspenger og barnetillegg etter forskrift om tiltakspenger § 7.",
   "tilleggstekst": "",
   "forhandsvisning": true
 }

--- a/templates/tpts/partials/base.hbs
+++ b/templates/tpts/partials/base.hbs
@@ -81,11 +81,9 @@
                 {{else}}
                     <p>-</p>
                 {{/if}}
-                <p>Beslutter </p>
             </div>
             <div>
                 <p>{{saksbehandlerNavn}}</p>
-                <p>Saksbehandler</p>
             </div>
         </div>
     </section>

--- a/templates/tpts/revurderingsvedtak.hbs
+++ b/templates/tpts/revurderingsvedtak.hbs
@@ -1,20 +1,17 @@
 {{#> tpts/partials/base}}
-<section>
+    <section>
         <h1>Nav har stanset tiltakspengene dine</h1>
 
         <h2>Vedtak</h2>
 
         <p>
-        Tiltakspengene {{#if barnetillegg}}og barnetillegg{{/if}} stanses fra og med {{rammevedtakFraDato}} til og med {{rammevedtakTilDato}} fordi du ikke lenger deltar i arbeidsmarkedstiltak.
+            Tiltakspenger {{#if barnetillegg}}og barnetillegg{{/if}} stanses fra og med {{virkningsperiodeFraDato}} fordi {{valgtHjemmelTekst}}.
         </p>
-        <p>
-            For å ha rett til tiltakspenger må du delta i arbeidsmarkedstiltak som gir rett til tiltakspenger.
-        </p>
-        <p>
-        Vi har fått beskjed om at tiltaket er avsluttet, og at du derfor fra og med {{rammevedtakFraDato}} ikke lenger deltar i tiltaket.
-        </p>
-        <p>
-        Vedtaket er gjort etter Lov om arbeidsmarkedstjenester § 13 første ledd og tiltakspengeforskriften §2.
-        </p>
-</section>
+
+        {{#if tilleggstekst}}
+            <h2>Nav sin vurdering</h2>
+            <!--        Om man ønsker linebreaks mellom tilleggstekstene (fordi bruker kan ha limt inn flere) må de skilles med '\n\n'-->
+            <p>{{breaklines tilleggstekst}}</p>
+        {{/if}}
+    </section>
 {{/tpts/partials/base}}

--- a/templates/tpts/revurderingsvedtak.hbs
+++ b/templates/tpts/revurderingsvedtak.hbs
@@ -5,7 +5,13 @@
         <h2>Vedtak</h2>
 
         <p>
-            Tiltakspenger {{#if barnetillegg}}og barnetillegg{{/if}} stanses fra og med {{virkningsperiodeFraDato}} fordi {{valgtHjemmelTekst}}
+            Tiltakspenger {{#if barnetillegg}}og barnetillegg{{/if}} stanses fra og med {{virkningsperiodeFraDato}} fordi
+            {{#each valgtHjemmelTekst}}
+                <!-- revurdering til stans skal bare støtte at man har valgt en hjemmel. Om flere skal støttes burde man kanskje brukt kulepunkter?-->
+                {{#eq @index 0}}
+                    {{this}}
+                {{/eq}}
+            {{/each}}
         </p>
 
         {{#if tilleggstekst}}

--- a/templates/tpts/revurderingsvedtak.hbs
+++ b/templates/tpts/revurderingsvedtak.hbs
@@ -5,7 +5,7 @@
         <h2>Vedtak</h2>
 
         <p>
-            Tiltakspenger {{#if barnetillegg}}og barnetillegg{{/if}} stanses fra og med {{virkningsperiodeFraDato}} fordi {{valgtHjemmelTekst}}.
+            Tiltakspenger {{#if barnetillegg}}og barnetillegg{{/if}} stanses fra og med {{virkningsperiodeFraDato}} fordi {{valgtHjemmelTekst}}
         </p>
 
         {{#if tilleggstekst}}

--- a/templates/tpts/revurderingsvedtak.hbs
+++ b/templates/tpts/revurderingsvedtak.hbs
@@ -9,7 +9,7 @@
         </p>
 
         {{#if tilleggstekst}}
-            <h2>Nav sin vurdering</h2>
+            <h2>Slik har vi vurdert saken din</h2>
             <!--        Om man ønsker linebreaks mellom tilleggstekstene (fordi bruker kan ha limt inn flere) må de skilles med '\n\n'-->
             <p>{{breaklines tilleggstekst}}</p>
         {{/if}}

--- a/templates/tpts/vedtakInnvilgelse.hbs
+++ b/templates/tpts/vedtakInnvilgelse.hbs
@@ -26,7 +26,7 @@
             lønnet arbeid som en del av oppfølgingen i tiltaket ditt.</p>
 
         {{#if tilleggstekst}}
-            <h2>Vår vurdering</h2>
+            <h2>Nav sin vurdering</h2>
             <!--        Om man ønsker linebreaks mellom tilleggstekstene (fordi bruker kan ha limt inn flere) må de skilles med '\n\n'-->
             <p>{{breaklines tilleggstekst}}</p>
         {{/if}}

--- a/templates/tpts/vedtakInnvilgelse.hbs
+++ b/templates/tpts/vedtakInnvilgelse.hbs
@@ -26,7 +26,7 @@
             lønnet arbeid som en del av oppfølgingen i tiltaket ditt.</p>
 
         {{#if tilleggstekst}}
-            <h2>Nav sin vurdering</h2>
+            <h2>Slik har vi vurdert saken din</h2>
             <!--        Om man ønsker linebreaks mellom tilleggstekstene (fordi bruker kan ha limt inn flere) må de skilles med '\n\n'-->
             <p>{{breaklines tilleggstekst}}</p>
         {{/if}}


### PR DESCRIPTION
## Beskrivelse
Revurderingsbrevet endres til å kunne  ta imot et valgt hjemmel for hvorfor tiltakspengene stanses og en fritekst


## Kommentarer
Ekstra
+ Fjerner saksbehandler/beslutter fra signatur da bruker ikke har noe forhold til dette
+ Endrer overskrift for fritekst til å være likt som hos tilleggstønader: "Nav sin vurdering" => "Slik har vi vurdert saken din"